### PR TITLE
Adding an optional delimiter parameter to listagg_clob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# listagg_clob
+f# listagg_clob
 extends listagg beyond its varchar2 limits
 
-"Standard" LISTAGG takes varchar2 and returns a concatenation that may be longer than the limit of varchar2 which can be problematic.  LISTAGG_CLOB takes *varchar2* inputs and returns a clob to workaround the limitation of the *output* length. There is an optional delimiter parameter which can be any character or sring up to 255 charactwers in length. This defaults to ','.
+"Standard" LISTAGG takes varchar2 and returns a concatenation that may be longer than the limit of varchar2 which can be problematic.  LISTAGG_CLOB takes *varchar2* inputs and returns a clob to workaround the limitation of the *output* length. There is an optional delimiter parameter which can be any character or string up to 255 characters in length. This defaults to ','.
 
 
 ## Installation Guide

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-f# listagg_clob
-extends listagg beyond its varchar2 limits
+listagg_clob extends listagg beyond its varchar2 limits
 
 "Standard" LISTAGG takes varchar2 and returns a concatenation that may be longer than the limit of varchar2 which can be problematic.  LISTAGG_CLOB takes *varchar2* inputs and returns a clob to workaround the limitation of the *output* length. There is an optional delimiter parameter which can be any character or string up to 255 characters in length. This defaults to ','.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # listagg_clob
 extends listagg beyond its varchar2 limits
 
-"Standard" LISTAGG takes varchar2 and returns a concatenation that may be longer than the limit of varchar2 which can be problematic.  LISTAGG_CLOB takes *varchar2* inputs and returns a clob to workaround the limitation of the *output* length.
+"Standard" LISTAGG takes varchar2 and returns a concatenation that may be longer than the limit of varchar2 which can be problematic.  LISTAGG_CLOB takes *varchar2* inputs and returns a clob to workaround the limitation of the *output* length. There is an optional delimiter parameter which can be any character or sring up to 255 charactwers in length. This defaults to ','.
 
 
 ## Installation Guide
@@ -15,13 +15,25 @@ extends listagg beyond its varchar2 limits
 ## Sample Usage
 
 ```console
-SQL> select listagg_clob(owner, ',')
+SQL> select listagg_clob(owner)
   2  from dba_objects
   3  where rownum <= 10;
 
 LISTAGG_CLOB(OWNER)
 -----------------------------------------------
 SYS,SYS,SYS,SYS,SYS,SYS,SYS,SYS,SYS,SYS
+
+1 row selected.
+```
+
+```console
+SQL> select listagg_clob(owner, '; ')
+  2  from dba_objects
+  3  where rownum <= 10;
+
+LISTAGG_CLOB(OWNER)
+----------------------------------------------------
+SYS; SYS; SYS; SYS; SYS; SYS; SYS; SYS; SYS; SYS
 
 1 row selected.
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ extends listagg beyond its varchar2 limits
 ## Sample Usage
 
 ```console
-SQL> select listagg_clob(owner)
+SQL> select listagg_clob(owner, ',')
   2  from dba_objects
   3  where rownum <= 10;
 

--- a/listagg_clob.sql
+++ b/listagg_clob.sql
@@ -1,4 +1,4 @@
-create or replace function listagg_clob( agg varchar2 )
+create or replace function listagg_clob( agg varchar2, delim in varchar2 default ',')
 return clob
 parallel_enable aggregate using listagg_clob_t;
 /

--- a/listagg_clob_t_tb.sql
+++ b/listagg_clob_t_tb.sql
@@ -1,10 +1,11 @@
 create or replace type body listagg_clob_t
 is
-  static function odciaggregateinitialize( sctx in out listagg_clob_t )
+  static function odciaggregateinitialize( sctx in out listagg_clob_t
+                                         , delim in varchar2 default ',' )
   return number
   is
   begin
-    sctx := listagg_clob_t( null, null );
+    sctx := listagg_clob_t( null, delim, null );
     return odciconst.success;
   end;
 --
@@ -26,7 +27,7 @@ is
         if self.t_varchar2 is null then
           self.t_varchar2 := self.t_varchar2 || p_val;
         else
-          self.t_varchar2 := self.t_varchar2 || ',' || p_val;
+          self.t_varchar2 := self.t_varchar2 || self.t_delim || p_val;
         end if;
       else
         if self.t_clob is null
@@ -34,7 +35,7 @@ is
           dbms_lob.createtemporary( self.t_clob, true, dbms_lob.call );
           dbms_lob.writeappend( self.t_clob, length( self.t_varchar2 ), self.t_varchar2 );
         else
-          dbms_lob.writeappend( self.t_clob, length( self.t_varchar2 ), ','||self.t_varchar2 );
+          dbms_lob.writeappend( self.t_clob, length( self.t_varchar2 ), self.t_delim || self.t_varchar2 );
         end if;
         self.t_varchar2 := p_val;
       end if;
@@ -93,5 +94,3 @@ is
   end;
 --
 end;
-/
-sho err

--- a/listagg_clob_t_ts.sql
+++ b/listagg_clob_t_ts.sql
@@ -1,7 +1,9 @@
 create or replace type listagg_clob_t as object
 ( t_varchar2 varchar2(32767)
+, t_delim varchar2(255)
 , t_clob clob
-, static function odciaggregateinitialize( sctx in out listagg_clob_t )
+, static function odciaggregateinitialize( sctx in out listagg_clob_t
+                                         , delim in varchar2 default ',' )
   return number
 , member function odciaggregateiterate
     ( self in out listagg_clob_t


### PR DESCRIPTION
This enhancement adds an optional delimiter parameter to the excellent **listagg_clob** by Connor McDonald. The new parameter defaults to a comma which means any existing code using unmodified listagg_clob will not break.

You can now specify any delimiter up to 255 characters in length.

Usage: `listagg_clob(<data>,'<delimiter>')`

e.g.
`select listagg_clob(varchar2_column,'; ') clob_data`
`from   data_table;`
